### PR TITLE
use join to be explicit

### DIFF
--- a/registries/installers/yarn.js
+++ b/registries/installers/yarn.js
@@ -7,7 +7,7 @@ class Yarn {
     var cwd = options.cwd || process.cwd;
     var env = options.env || process.env;
     var packageInstall = packageInstallParser(packages);
-    var yarnExec = path.resolve(process.cwd(), "./node_modules/.bin/yarn");
+    var yarnExec = path.join(process.cwd(), "./node_modules/.bin/yarn");
 
     return exec(yarnExec, ["add", ...packageInstall], { cwd, env }).then(() => packages);
   }


### PR DESCRIPTION
Using process.cwd() is being explicit for intent, so use path.join
instead of path.resolve to match that explicit intent.